### PR TITLE
Standardize spacing in status.conf.

### DIFF
--- a/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/status.conf
+++ b/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/status.conf
@@ -1,46 +1,45 @@
 server {
-	# Status page is enabled on port 8080 by default.
-	listen 8080;
+    # Status page is enabled on port 8080 by default.
+    listen 8080;
 
-	# Status zone allows the status page to display statistics for the whole server block.
-	# It should be enabled for every server block in other configuration files.
-	status_zone status-page;
+    # Status zone allows the status page to display statistics for the whole server block.
+    # It should be enabled for every server block in other configuration files.
+    status_zone status-page;
 
-	# In case of nginx process listening on multiple IPs you can restrict status page
-	# to single IP only
-	# listen 10.2.3.4:8080;
+    # In case of nginx process listening on multiple IPs you can restrict status page
+    # to single IP only
+    # listen 10.2.3.4:8080;
 
-	# HTTP basic Authentication is enabled by default.
-	# You can add users with any htpasswd generator.
-	# Command line and online tools are very easy to find.
-	# You can also reuse your htpasswd file from Apache web server installation.
-	#auth_basic on;
-	#auth_basic_user_file /etc/nginx/users;
+    # HTTP basic Authentication is enabled by default.
+    # You can add users with any htpasswd generator.
+    # Command line and online tools are very easy to find.
+    # You can also reuse your htpasswd file from Apache web server installation.
+    #auth_basic on;
+    #auth_basic_user_file /etc/nginx/users;
 
-	# It is recommended to limit the use of status page to admin networks only
-	# Uncomment and change the network accordingly.
-	#allow 10.0.0.0/8;
-	#deny all;
+    # It is recommended to limit the use of status page to admin networks only
+    # Uncomment and change the network accordingly.
+    #allow 10.0.0.0/8;
+    #deny all;
 
-	# NGINX provides a sample HTML status page for easy dashboard view
-	root /usr/share/nginx/html;
-	location = /status.html { }
+    # NGINX provides a sample HTML status page for easy dashboard view
+    root /usr/share/nginx/html;
+    location = /status.html { }
 
-	# Standard HTTP features are fully supported with the status page.
-	# An example below provides a redirect from "/" to "/status.html"
-	location = / {
-		return 301 /status.html;
-	}
+    # Standard HTTP features are fully supported with the status page.
+    # An example below provides a redirect from "/" to "/status.html"
+    location = / {
+        return 301 /status.html;
+    }
 
-	# Main status location. HTTP features like authentication, access control,
-	# header changes, logging are fully supported.
-	location /status {
-		status;
-		status_format json;
-	}
+    # Main status location. HTTP features like authentication, access control,
+    # header changes, logging are fully supported.
+    location /status {
+        status;
+        status_format json;
+    }
 
-	location ~ /favicon.ico {
-		root /usr/share/nginx/images;
-	}
-
+    location ~ /favicon.ico {
+        root /usr/share/nginx/images;
+    }
 }


### PR DESCRIPTION
Standardizing spacing in status.conf to use 4 spaces per level of indent, instead of a mix of tabs and spaces.