### PR TITLE
apt-key is deprecated. Updated PGP keyring method

### DIFF
--- a/nginx-regex-tester/regextester/Dockerfile
+++ b/nginx-regex-tester/regextester/Dockerfile
@@ -5,7 +5,7 @@ RUN chmod +x /usr/local/sbin/start.sh
 
 RUN apt-get update && apt-get install -y -q wget curl apt-transport-https lsb-release ca-certificates gnupg
 
-RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | apt-key add -
+RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg
 
 RUN rm /etc/nginx/conf.d/*
 COPY regextester.conf /etc/nginx/conf.d

--- a/nginx-regex-tester/regextester/Dockerfile
+++ b/nginx-regex-tester/regextester/Dockerfile
@@ -5,7 +5,7 @@ RUN chmod +x /usr/local/sbin/start.sh
 
 RUN apt-get update && apt-get install -y -q wget curl apt-transport-https lsb-release ca-certificates gnupg
 
-RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg
+RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg
 
 RUN rm /etc/nginx/conf.d/*
 COPY regextester.conf /etc/nginx/conf.d


### PR DESCRIPTION
Changed to the new-style key add, followed directions from here: https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html