### PR TITLE
Draft: Adding playbook for installing NMS and NGINX Agent

### DIFF
--- a/nginx-plus-count/README.md
+++ b/nginx-plus-count/README.md
@@ -1,0 +1,55 @@
+# Ansible Playbook to Manage NGINX Plus Instances via NGINX Management Suite (NMS)
+
+This is an example playbook to get a total number of NGINX Plus instances and to meet the requirement of having NGINX Plus managed by NMS. The playbooks will do the following:
+* *nms-agent-install.yml*
+  * Install NMS on separate host
+  * Install NGINX Agent on NGINX Plus instances
+* *nms-agent-upgrade.yml*
+  * Upgrade NMS if available
+  * Upgrade NGINX Agent if available
+
+## Prerequisites
+
+1. Separate Host for NMS
+1. Install Required Ansible Collection and Roles
+
+### Separate Host for NMS
+
+This playbook requires a separate host for NMS installation. Take a look at [NMS Supported Distributions](https://docs.nginx.com/nginx-management-suite/overview/tech-specs/#supported-distributions).
+
+### Install Required Ansible Collection and Roles 
+
+This playbook depends on the following roles and collections below so be sure to install these via `ansible-galaxy`.
+1. [NGINX Management Suite Ansible Role](https://github.com/nginxinc/ansible-role-nginx-management-suite)
+2. [NGINX Ansible Role](https://github.com/nginxinc/ansible-role-nginx)
+3. [NGINX Management Suite Collection](https://github.com/TuxInvader/ansible_collection_nginx_management_suite)
+
+## Usage
+
+### Installing Collection and Roles
+
+An example of installing these can be ran by using the following commands.
+```shell
+ansible-galaxy install -r requirement.yml
+ansible-galaxy collection install -r requirement.collection.yaml
+```
+
+### Create Inventory File
+
+Look at the `inventory.sample` file for a sample but defining the the hosts.
+
+### Install NMS and NGINX Agent
+
+Run the following command to start the playbook to install NMS and NGINX Agents on your NGINX Plus instances.
+
+```shell
+ansible-playbook -i inventory.sample nms-agent-install.yml
+```
+
+### Update NMS and NGINX Agent
+
+It is a good idea to keep NMS and NGINX Agent up to date. Below is an example playbook that will update NMS and NGINX Agent.
+
+```shell
+ansible-playbook -i inventory.sample nms-agent-upgrade.yml
+```

--- a/nginx-plus-count/inventory.sample
+++ b/nginx-plus-count/inventory.sample
@@ -1,0 +1,6 @@
+[nms]
+x.x.x.x ansible_user=<username>  ansible_become=yes
+
+[data]
+y.y.y.y ansible_user=<username>  ansible_become=yes
+z.z.z.z ansible_user=<username>  ansible_become=yes

--- a/nginx-plus-count/nms-agent-install.yml
+++ b/nginx-plus-count/nms-agent-install.yml
@@ -1,0 +1,27 @@
+---
+- name: Install NGINX Management Suite (NMS)
+  hosts: nms
+  vars:
+    nms_version: 2.6.0*
+    nms_setup: install
+    nms_password: 'Password123'
+    nginx_setup: install
+    nginx_license:
+      certificate: "{{playbook_dir}}/nginx-repo.crt"
+      key: "{{playbook_dir}}/nginx-repo.key" 
+
+  tasks:
+    - name: Install NMS
+      ansible.builtin.include_role:
+        name: nginxinc.nms_install
+
+- name: Install NGINX Agent on data plane hosts
+  hosts: data
+  vars:
+    nms_fqdn:  "{{ groups.nms[0] }}"
+    nms_validate_certs: false
+
+  tasks:
+    - name: Install NGINX Agent on NGINX Plus Hosts
+      ansible.builtin.include_role:
+        name: nginxinc.nginx_management_suite.nms_agent_config

--- a/nginx-plus-count/nms-agent-upgrade.yml
+++ b/nginx-plus-count/nms-agent-upgrade.yml
@@ -1,0 +1,36 @@
+---
+- name: Upgrade NMS
+  hosts: nms
+  vars:
+    nms_setup: upgrade
+    nms_password: 'Password123'
+    nginx_setup: upgrade
+    nginx_license:
+      certificate: "{{playbook_dir}}/nginx-repo.crt"
+      key: "{{playbook_dir}}/nginx-repo.key" 
+
+  tasks:
+    - name: Upgrade NMS
+      ansible.builtin.include_role:
+        name: ansible-role-nginx-management-suite
+
+- name: Upgrade NGINX Agent on NGINX Plus Hosts
+  hosts: data
+  vars:
+    nms_fqdn:  "{{ groups.nms[0] }}"
+    nms_validate_certs: false
+
+  tasks:
+    - name: Remove file to force NGINX Agent Upgrade
+      ansible.builtin.file:
+        path: /etc/nginx-agent/nginx-agent.conf
+        state: absent
+
+    - name: Stopping nginx-agent
+      ansible.builtin.systemd:
+        name: nginx-agent
+        state: stopped
+
+    - name: Upgrade NGINX Agent on NGINX Plus Hosts
+      ansible.builtin.include_role:
+        name: nginxinc.nginx_management_suite.nms_agent_config

--- a/nginx-plus-count/requirement.collection.yml
+++ b/nginx-plus-count/requirement.collection.yml
@@ -1,0 +1,4 @@
+collections:
+  - name: https://github.com/TuxInvader/ansible_collection_nginx_management_suite.git
+    type: git
+    version: main

--- a/nginx-plus-count/requirement.yml
+++ b/nginx-plus-count/requirement.yml
@@ -1,0 +1,5 @@
+# from GitHub
+- src: https://github.com/nginxinc/ansible-role-nginx-management-suite.git
+  version: initial
+
+- src: https://github.com/nginxinc/ansible-role-nginx


### PR DESCRIPTION
Adding playbooks for NMS and NGINX Agent Install and Upgrade.

Once the ansible role for NMS install is complete, this PR can be completed.