### PR TITLE
Fix regextester docker build error: NO_PUBKEY ABF5BD827BD9BF62

### DIFF
--- a/nginx-regex-tester/regextester/Dockerfile
+++ b/nginx-regex-tester/regextester/Dockerfile
@@ -6,6 +6,7 @@ RUN chmod +x /usr/local/sbin/start.sh
 RUN apt-get update && apt-get install -y -q wget curl apt-transport-https lsb-release ca-certificates gnupg
 
 RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg
+RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | apt-key add -
 
 RUN rm /etc/nginx/conf.d/*
 COPY regextester.conf /etc/nginx/conf.d


### PR DESCRIPTION
When running "docker compose up -d" in nginx-regex-tester/,  get this error:

```
=> ERROR [regextester 10/13] RUN apt-get update && apt-get install -y unit php7.0 unit-php                                             3.0s
------
 > [regextester 10/13] RUN apt-get update && apt-get install -y unit php7.0 unit-php:
0.887 Hit:1 http://deb.debian.org/debian bookworm InRelease
1.480 Hit:2 http://deb.debian.org/debian bookworm-updates InRelease
1.808 Get:3 https://packages.nginx.org/unit/debian bookworm InRelease [2803 B]
2.021 Err:3 https://packages.nginx.org/unit/debian bookworm InRelease
2.021   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABF5BD827BD9BF62
2.096 Hit:4 http://deb.debian.org/debian-security bookworm-security InRelease
2.179 Reading package lists...
3.026 W: GPG error: https://packages.nginx.org/unit/debian bookworm InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABF5BD827BD9BF62
3.026 E: The repository 'https://packages.nginx.org/unit/debian bookworm InRelease' is not signed.
```

This commit fixes the docker building.