### PR TITLE
deprecations: handle njs deprecations from version 0.8.0

### DIFF
--- a/oauth2-token-introspection-oss/oauth2.js
+++ b/oauth2-token-introspection-oss/oauth2.js
@@ -19,13 +19,13 @@ function introspectAccessToken(r) {
     var authHeader = "";
     if (r.variables.oauth_client_id.length) {
         var basicAuthPlaintext = r.variables.oauth_client_id + ":" + r.variables.oauth_client_secret;
-        authHeader = "Basic " + basicAuthPlaintext.toBytes().toString('base64');    
+        authHeader = "Basic " + Buffer.from(basicAuthPlaintext).toString('base64');
     } else {
         authHeader = "Bearer " + r.variables.oauth_client_secret;
     }
 
     // Make the OAuth 2.0 Token Introspection request
-    r.log("OAuth sending introspection request with token: " + r.variables.access_token)
+    r.log("OAuth sending introspection request with token: " + r.variables.access_token);
     r.subrequest("/_oauth2_send_introspection_request", "token=" + r.variables.access_token + "&authorization=" + authHeader,
         function(reply) {
             if (reply.status != 200) {
@@ -35,8 +35,8 @@ function introspectAccessToken(r) {
 
             // We have a response from authorization server, validate it has expected JSON schema
             try {
-                r.log("OAuth token introspection response: " + reply.responseBody)
-                var response = JSON.parse(reply.responseBody);
+                r.log("OAuth token introspection response: " + reply.responseText);
+                var response = JSON.parse(reply.responseText);
                 // TODO: check for errors in the JSON response first
                 // We have a valid introspection response
                 // Check for validation success

--- a/oauth2-token-introspection-plus/oauth2.js
+++ b/oauth2-token-introspection-plus/oauth2.js
@@ -26,7 +26,7 @@ function introspectAccessToken(r) {
         var authHeader = "";
         if (r.variables.oauth_client_id.length) {
             var basicAuthPlaintext = r.variables.oauth_client_id + ":" + r.variables.oauth_client_secret;
-            authHeader = "Basic " + basicAuthPlaintext.toBytes().toString('base64');    
+            authHeader = "Basic " + Buffer.from(basicAuthPlaintext).toString('base64');
         } else {
             authHeader = "Bearer " + r.variables.oauth_client_secret;
         }
@@ -43,18 +43,18 @@ function introspectAccessToken(r) {
 
                 // We have a response from authorization server, validate it has expected JSON schema
                 try {
-                    r.log("OAuth token introspection response: " + reply.responseBody)
-                    var response = JSON.parse(reply.responseBody); // Test for valid JSON so that we only store good responses
+                    r.log("OAuth token introspection response: " + reply.responseText);
+                    var response = JSON.parse(reply.responseText); // Test for valid JSON so that we only store good responses
                     if (response.active.length) {
                         r.variables.token_data = response.toString('base64'); // Store this repsonse in keyval zone
                         tokenResult(r);
                     } else {
-                        r.error("OAuth error in token introspection response: " + reply.responseBody);
+                        r.error("OAuth error in token introspection response: " + reply.responseText);
                         r.return(401);
                         return;
                     }
                 } catch (e) {
-                    r.error("OAuth token introspection response is not JSON: " + reply.responseBody);
+                    r.error("OAuth token introspection response is not JSON: " + reply.responseText);
                     r.return(401);
                 }
             }


### PR DESCRIPTION
Handle the deprecations introduced by njs 0.8.0.

OSS tested, NGINX Plus untested, but should carry over 1:1.

Fixes:
Fixes #120 #119 #106 