### PR TITLE
(regextester) Update the gpg key(nginx_signing.key) for packages.nginx.org

### DIFF
--- a/nginx-regex-tester/regextester/Dockerfile
+++ b/nginx-regex-tester/regextester/Dockerfile
@@ -5,7 +5,7 @@ RUN chmod +x /usr/local/sbin/start.sh
 
 RUN apt-get update && apt-get install -y -q wget curl apt-transport-https lsb-release ca-certificates gnupg
 
-RUN wget -q -O - http://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg
+RUN wget -q -O - https://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg
 RUN wget -q -O - https://unit.nginx.org/keys/nginx-keyring.gpg | gpg --dearmor > /usr/share/keyrings/nginx-keyring.gpg
 
 RUN rm /etc/nginx/conf.d/*


### PR DESCRIPTION
This PR is related to #97

[Reason]
when download GPG key(nginx_signing.key) by HTTP protocol using `wget` is stuck for TLS connection

[Debug]
- `curl` responses to HTTP endpoint is "curl: (52) Empty reply from server"

[Fix below Issues]
- #129
- #124