### PR TITLE
ci: pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -40,29 +40,29 @@ jobs:
           echo "image=${image}" >> $GITHUB_OUTPUT
       - name: Check if update needed for ${{ steps.variables.outputs.image }}
         id: update
-        uses: lucacome/docker-image-update-checker@v2
+        uses: lucacome/docker-image-update-checker@a233de0585661c019fb71f9601328db37051cc66 # v2
         with:
           base-image: library/nginx:mainline-alpine
           image: ${{ steps.variables.outputs.image }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: ${{ steps.update.outputs.needs-updating == 'true' || inputs.force == 'true' }}
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm/v6,arm,arm64,amd64,ppc64le,s390x,386
         if: ${{ steps.update.outputs.needs-updating == 'true' || inputs.force == 'true' }}
       - name: Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         if: ${{ steps.update.outputs.needs-updating == 'true' || inputs.force == 'true' }}
       - name: DockerHub Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
         if: ${{ steps.update.outputs.needs-updating == 'true' || inputs.force == 'true' }}
       - name: Push to Dockerhub for nginx-hello
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,4 +66,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3


### PR DESCRIPTION
## Summary

Pin action refs from mutable tags to full commit SHAs to prevent supply-chain attacks.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `lucacome/docker-image-update-checker` | `v2` | `a233de05...` |
| `actions/checkout` | `v4` | `34e11487...` |
| `docker/setup-qemu-action` | `v3` | `c7c53464...` |
| `docker/setup-buildx-action` | `v3` | `8d2750c6...` |
| `docker/login-action` | `v3` | `c94ce9fb...` |
| `docker/build-push-action` | `v6` | `10e90e36...` |
| `github/codeql-action/init` | `v3` | `ebcb5b36...` |
| `github/codeql-action/analyze` | `v3` | `ebcb5b36...` |

Applied to: `build-docker.yml`, `codeql-analysis.yml`

No behavioral changes — supply-chain hardening only.